### PR TITLE
Tweak page read padding on history screen

### DIFF
--- a/app/src/main/java/eu/kanade/presentation/history/components/HistoryItem.kt
+++ b/app/src/main/java/eu/kanade/presentation/history/components/HistoryItem.kt
@@ -89,7 +89,7 @@ fun HistoryItem(
             if (readProgress != null) {
                 Text(
                     text = readProgress,
-                    modifier = Modifier.padding(top = 2.dp),
+                    modifier = Modifier.padding(top = 4.dp),
                     style = textStyle,
                     color = MaterialTheme.colorScheme.onSurface.copy(alpha = DISABLED_ALPHA),
                 )


### PR DESCRIPTION
<!--
  Please include a summary of the change and which issue is fixed.
  Also make sure you've tested your code and also done a self-review of it.
  Don't forget to check all base themes and tablet mode for relevant changes.
  
  If your changes are visual, please provide images below:

### Images
| Image 1 | Image 2 |
| ------- | ------- |
| ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) | ![](https://github.githubassets.com/images/modules/logos_page/Octocat.png) |
-->
